### PR TITLE
Correct command for headless build

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ Foreground mode (chromedriver required)
 
 Headless mode (Selenium Docker required)
 
-    SELENIUM_REMOTE_URL=YOUR_HOST_IP python manage.py buildguide --headless
+    SELENIUM_REMOTE_URL=YOUR_HOST_IP HEADLESS=1 python manage.py buildguide
 
 To convert markdown to documentation, I'd suggest using MkDocs. In your project root:
 


### PR DESCRIPTION
The `buildguide` command doesn't take a `--headless` argument; rather, it checks for the presence of a `HEADLESS` environment variable:

https://github.com/allcaps/wagtail-guide/blob/aa78b931662c5b558ef9df77fab3b60b856a02e9/src/wagtail_guide/tests/conftest.py#L43