### PR TITLE
Add links to video output and Wagtail Space talk

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # Wagtail Guide
 
-A user guide for Wagtail powered sites.
+A user guide for Wagtail powered sites, generating screenshots and [video recordings](https://www.youtube.com/watch?v=E3-kFY6jPPY).
+
+> View the Wagtail Space US 2022 talk: [Wagtail Guide - Coen van der Kamp](https://www.youtube.com/watch?v=W0tL-5V5BWA)
 
 Wagtail guide uses Pytest + Selenium + Markdown + MKDocs. 
 


### PR DESCRIPTION
I thought those two would be well worth adding to the README. Feel free to change the formatting as you see fit!

Here is a Markdown "YouTube player" as an alternative:

```markdown
[![Video recording of Wagtail Guide - Coen van der Kamp, Wagtail Space US 2022](https://i.ytimg.com/vi_webp/W0tL-5V5BWA/sddefault.webp)](https://www.youtube.com/watch?v=W0tL-5V5BWA)
```

[![Video recording of Wagtail Guide - Coen van der Kamp, Wagtail Space US 2022](https://i.ytimg.com/vi_webp/W0tL-5V5BWA/sddefault.webp)](https://www.youtube.com/watch?v=W0tL-5V5BWA)